### PR TITLE
Bug fix: delete range can not remove expected data

### DIFF
--- a/dbms/src/Interpreters/Settings.h
+++ b/dbms/src/Interpreters/Settings.h
@@ -256,6 +256,7 @@ struct Settings
     M(SettingBool, dt_read_stable_only, false, "Only read stable data in DeltaTree Engine.")\
     M(SettingBool, dt_enable_logical_split, true, "Enable logical split or not in DeltaTree Engine.")\
     M(SettingBool, dt_flush_after_write, false, "Flush cache or not after write in DeltaTree Engine.")\
+    M(SettingBool, dt_enable_relevant_place, true, "Enable relevant place or not in DeltaTree Engine.")\
     M(SettingBool, dt_enable_skippable_place, true, "Enable skippable place or not in DeltaTree Engine.")\
     M(SettingBool, dt_enable_stable_column_cache, true, "Enable column cache for StorageDeltaMerge.") \
     M(SettingUInt64, dt_open_file_max_idle_seconds, 15, "Max idle time of opening files, 0 means infinite.") \

--- a/dbms/src/Storages/DeltaMerge/DMContext.h
+++ b/dbms/src/Storages/DeltaMerge/DMContext.h
@@ -52,6 +52,7 @@ struct DMContext : private boost::noncopyable
     const bool enable_logical_split;
     const bool read_delta_only;
     const bool read_stable_only;
+    const bool enable_relevant_place;
     const bool enable_skippable_place;
 
 public:
@@ -77,6 +78,7 @@ public:
           enable_logical_split(settings.dt_enable_logical_split),
           read_delta_only(settings.dt_read_delta_only),
           read_stable_only(settings.dt_read_stable_only),
+          enable_relevant_place(settings.dt_enable_relevant_place),
           enable_skippable_place(settings.dt_enable_skippable_place)
     {
     }

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -1177,7 +1177,7 @@ std::pair<DeltaIndexPtr, bool> Segment::ensurePlace(const DMContext &         dm
     auto my_delta_index = delta_snap->shared_delta_index->tryClone(delta_snap->rows, delta_snap->deletes);
     auto my_delta_tree  = my_delta_index->getDeltaTree();
 
-    HandleRange relevant_range = mergeRanges(read_ranges);
+    HandleRange relevant_range = dm_context.enable_relevant_place ? mergeRanges(read_ranges) : HandleRange::newAll();
 
     auto [my_placed_rows, my_placed_deletes] = my_delta_index->getPlacedStatus();
 

--- a/dbms/src/Storages/DeltaMerge/Segment.cpp
+++ b/dbms/src/Storages/DeltaMerge/Segment.cpp
@@ -1305,7 +1305,7 @@ bool Segment::placeDelete(const DMContext &         dm_context,
             compacted_index->end(),
             dm_context.stable_pack_rows);
 
-        delete_stream = std::make_shared<DMHandleFilterBlockInputStream<true>>(delete_stream, delete_range.shrink(relevant_range), 0);
+        delete_stream = std::make_shared<DMHandleFilterBlockInputStream<true>>(delete_stream, delete_range, 0);
 
         // Try to merge into big block. 128 MB should be enough.
         SquashingBlockInputStream squashed_delete_stream(delete_stream, 0, 128 * (1UL << 20));


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Currently in DT engine, we only do place index for relevant query ranges in a segment. It can speed up individual region read, but the result of place index can not be shared between other region reads. It will eventually slow down the whole query processing if we have lots of cop requests.

### What is changed and how it works?


What's Changed:

1. This PR adds a new option `dt_enable_relevant_place`, and by default set to `true`, means enabling relevant place. The behavior is the same as the previous, but we can use the option to disable the relevant place.
2. Fix bug: delete range can not remove expected data

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
